### PR TITLE
use env variables instead json file for variables

### DIFF
--- a/src/lib/firebase-admin.ts
+++ b/src/lib/firebase-admin.ts
@@ -1,18 +1,18 @@
 import { initializeApp, getApps, cert } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 
-const serviceAccount = require('../../deneb-88a71-firebase-adminsdk-3z447-5d0122f45c.json');
-
-if (!serviceAccount) {
-  throw new Error('Missing FIREBASE_SERVICE_ACCOUNT environment variable');
-}
-
 const apps = getApps();
-
 const adminApp =
   apps.length === 0
     ? initializeApp({
-        credential: cert(serviceAccount),
+        credential: cert({
+          projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+          clientEmail: process.env.NEXT_PUBLIC_FIREBASE_CLIENT_EMAIL,
+          privateKey: process.env.NEXT_PUBLIC_FIREBASE_PRIVATE_KEY?.replace(
+            /\\n/g,
+            '\n'
+          ),
+        }),
       })
     : apps[0];
 


### PR DESCRIPTION
Fix build issue: use environment variables instead of reading them from a JSON file.