### PR TITLE
hotfix: In next 16 params is no more a plain object, it's a promise, so use await for the same.

### DIFF
--- a/src/app/competitive-programming/patterns/[...patternId]/page.tsx
+++ b/src/app/competitive-programming/patterns/[...patternId]/page.tsx
@@ -33,7 +33,8 @@ export const revalidate = 3600; // Revalidate at most every hour
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
-  const slug = params.patternId?.[0] || '';
+  const resolvedParams = await params;
+  const slug = resolvedParams.patternId?.[0] || '';
   const pattern = await getPatternBySlug(slug);
 
   if (!pattern) {
@@ -52,7 +53,6 @@ async function fetchPatternData(slug: string) {
   try {
     // Get the pattern by slug (uses cached version)
     const pattern = await getPatternBySlug(slug);
-
     if (!pattern) {
       console.log(`Pattern not found with slug: ${slug}`);
       notFound();
@@ -82,7 +82,8 @@ async function fetchPatternData(slug: string) {
 }
 
 export default async function PatternPage({ params }: PageProps) {
-  const patternId = params.patternId?.[0] || '';
+  const resolvedParams = await params;
+  const patternId = resolvedParams.patternId?.[0] || '';
   const { pattern, problems } = await fetchPatternData(patternId);
 
   return (


### PR DESCRIPTION
1. Fix page-breaking issue caused by the params object. In the earlier versions of Next.js, the params are plain objects, but in the new version (16), they are promises.