### PR TITLE
feat: use github actions to build and run test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,57 @@
+# .github/workflows/test.yml
+name: Test Suite
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Lint, Test & Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CI: true
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run tests with coverage
+        run: npm test -- --coverage --watchAll=false
+        env:
+          CI: true
+          NODE_ENV: test
+
+      - name: Build app
+        run: npm run build
+        env:
+          CI: true
+
+      - name: Upload test coverage
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,6 +18,8 @@ const customJestConfig = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest', // Use ts-jest for TypeScript files
   },
+  collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/**/*.d.ts'],
+  coveragePathIgnorePatterns: ['/node_modules/', '/.next/'],
 };
 
 module.exports = createJestConfig(customJestConfig);


### PR DESCRIPTION
## CI: Add automated lint, test, build & coverage

This PR adds a GitHub Actions workflow to automatically:

- Run ESLint checks
- Run Jest tests with coverage
- Build the application
- Upload coverage reports.

The CI runs on every push and pull request to `main` and `develop`, helping catch issues early and keep the codebase stable.
