### PR TITLE
fix: resolve admin navbar isAdmin prop, timestamp fields, and resume print layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@
 .DS_Store
 *.pem
 
+# Claude Code memory
+/memory/
+
 # debug
 npm-debug.log*
 yarn-debug.log*

--- a/src/app/api/users/[userId]/route.ts
+++ b/src/app/api/users/[userId]/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getUserData } from '@/lib/admin';
+
+export async function GET(
+  _request: NextRequest,
+  context: { params: Promise<{ userId: string }> }
+) {
+  try {
+    const { userId } = await context.params;
+    const userData = await getUserData(userId);
+
+    if (!userData) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    return NextResponse.json(userData);
+  } catch (error) {
+    console.error('Error fetching user:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch user' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/admin/AdminNavbar.tsx
+++ b/src/components/admin/AdminNavbar.tsx
@@ -13,7 +13,7 @@ import { useAuthRedux } from '@/hooks/useAuthRedux';
 export function AdminNavbar() {
   const router = useRouter();
   const pathname = usePathname();
-  const { currentUser } = useAuthRedux();
+  const { currentUser, isAdmin } = useAuthRedux();
 
   const isDashboard = pathname === '/admin';
 
@@ -29,10 +29,6 @@ export function AdminNavbar() {
 
     await signOut(auth);
     router.push('/login');
-  };
-
-  const handleMyAccountClick = () => {
-    router.push('my-account');
   };
 
   const handleSettingsClick = () => {
@@ -63,11 +59,9 @@ export function AdminNavbar() {
           {currentUser && (
             <div className="flex items-center gap-3">
               <UserDropDown
-                {...{
-                  handleSignOut,
-                  handleMyAccountClick,
-                  handleSettingsClick,
-                }}
+                handleSignOut={handleSignOut}
+                handleSettingsClick={handleSettingsClick}
+                isAdmin={isAdmin}
               />
             </div>
           )}

--- a/src/components/common/Navbar/index.tsx
+++ b/src/components/common/Navbar/index.tsx
@@ -98,7 +98,7 @@ const NavigationControls = ({
 );
 
 const Navbar = () => {
-  const { currentUser } = useAuthRedux();
+  const { currentUser, isAdmin } = useAuthRedux();
   const router = useRouter();
   const [canGoBack, setCanGoBack] = useState(false);
   const [canGoForward, setCanGoForward] = useState(false);
@@ -166,7 +166,7 @@ const Navbar = () => {
             <UserDropDown
               handleSignOut={handleSignOut}
               handleSettingsClick={handleSettingsClick}
-              userId={currentUser?.uid}
+              isAdmin={isAdmin}
             />
           )}
         </div>
@@ -192,7 +192,7 @@ const Navbar = () => {
                 <UserDropDown
                   handleSignOut={handleSignOut}
                   handleSettingsClick={handleSettingsClick}
-                  userId={currentUser?.uid}
+                  isAdmin={isAdmin}
                 />
               </div>
             )}

--- a/src/components/specific/UserDropDown/index.tsx
+++ b/src/components/specific/UserDropDown/index.tsx
@@ -15,18 +15,14 @@ import {
 type UserDropDownProps = {
   handleSignOut?: () => void;
   handleSettingsClick?: () => void;
-  userId?: string | null;
+  isAdmin?: boolean;
 };
-
-const ADMIN_USER_ID = process.env.NEXT_PUBLIC_FIREBASE_ADMIN_ACCOUNT_ID || '';
 
 function UserDropDown({
   handleSignOut,
   handleSettingsClick,
-  userId,
+  isAdmin,
 }: UserDropDownProps) {
-  const isAdmin = userId === ADMIN_USER_ID;
-
   return (
     <div>
       <DropdownMenu>

--- a/src/hooks/useAuthRedux.ts
+++ b/src/hooks/useAuthRedux.ts
@@ -60,8 +60,13 @@ export const useAuthRedux = () => {
         );
       }
 
-      const updatedUserDoc = await getDoc(userDocRef);
-      const docData = updatedUserDoc.data();
+      const latestDoc = await getDoc(userDocRef);
+      const docData = latestDoc.data();
+      const role = docData?.role ?? 'user';
+
+      const toISO = (ts: any) =>
+        ts?.toDate ? ts.toDate().toISOString() : (ts ?? null);
+
       const serializableUser = {
         uid: user.uid,
         email: user.email,
@@ -73,23 +78,10 @@ export const useAuthRedux = () => {
         providerData: user.providerData,
         phoneNumber: user.phoneNumber || null,
         providerId: user.providerId || null,
-        ...docData,
-        // Convert all Firestore Timestamps to ISO strings
-        createdAt: docData?.createdAt
-          ? docData.createdAt.toDate
-            ? docData.createdAt.toDate().toISOString()
-            : docData.createdAt
-          : null,
-        updatedAt: docData?.updatedAt
-          ? docData.updatedAt.toDate
-            ? docData.updatedAt.toDate().toISOString()
-            : docData.updatedAt
-          : null,
-        lastLogin: docData?.lastLogin
-          ? docData.lastLogin.toDate
-            ? docData.lastLogin.toDate().toISOString()
-            : docData.lastLogin
-          : null,
+        role,
+        createdAt: toISO(docData?.createdAt),
+        updatedAt: toISO(docData?.updatedAt),
+        lastLogin: toISO(docData?.lastLogin),
         proactiveRefresh: undefined,
         metadata: {
           creationTime: user.metadata?.creationTime || '',


### PR DESCRIPTION
 - **Refactor admin detection** — moved `isAdmin` check from `UserDropDown` (env-var UID
  comparison) into Redux state derived from Firestore `role` field; `Navbar` and
  `AdminNavbar` now pass `isAdmin` as a boolean prop instead of `userId`
  - **Restore Firestore timestamp fields** — `createdAt`, `updatedAt`, and `lastLogin` are
  now serialized back into Redux user state via a `toISO` helper, replacing the previous
  `...docData` spread that caused Firestore Timestamp serialization errors
  - **Add user data API route** — new `GET /api/users/[userId]` route backed by Firebase
  Admin SDK
  - **Housekeeping** — added `/memory/` to `.gitignore`

  ## Changes

  | File | What changed |
  |---|---|
  | `src/hooks/useAuthRedux.ts` | Extract only `role` + timestamps from Firestore doc;
  `toISO` helper for safe Timestamp serialization |
  | `src/components/specific/UserDropDown/index.tsx` | Replace `userId` + env-var
  comparison with `isAdmin?: boolean` prop |
  | `src/components/common/Navbar/index.tsx` | Pass `isAdmin` from Redux instead of
  `currentUser?.uid` |
  | `src/components/admin/AdminNavbar.tsx` | Destructure `isAdmin` from `useAuthRedux`;
  remove unused `handleMyAccountClick` |
  | `src/app/api/users/[userId]/route.ts` | New route — fetch user profile via
  `getUserData` from `@/lib/admin` |
  | `.gitignore` | Ignore `/memory/` (Claude Code local memory directory) |

  ## Bugs fixed during review

  The following issues were caught in pre-merge code review and fixed in this branch:

  **AdminNavbar — admin link never showed (confirmed bug)**
  `AdminNavbar` was spreading `{ handleSignOut, handleMyAccountClick, handleSettingsClick
  }` onto `UserDropDown`. After the prop rename, `handleMyAccountClick` became an unknown
  prop (silently dropped) and `isAdmin` was never passed — meaning the Admin Panel link was
   permanently hidden for admins using the admin navbar.

  **Timestamp fields dropped from Redux user state (confirmed bug)**
  The refactor removed `...docData` and replaced it with just `role`, silently dropping
  `createdAt`, `updatedAt`, and `lastLogin` from the serialized user object. These fields
  are declared on `AppUser` and would always read as `undefined` from Redux state. Fixed by
   explicitly mapping each field through a `toISO` helper.

  **`page-break-inside: avoid` applied to entire section wrappers (confirmed bug)**
  Print CSS was targeting `.experience-section`, `.education-section`, `.projects-section`
  — entire wrappers containing multiple entries. This forced the whole section to jump to a
   new page rather than allowing natural breaks between individual entries. Fixed by adding
   a `resume-entry` class to each individual entry card and targeting that instead.

  **Sidebar height not guaranteed in PDF export (plausible)**
  Removing `h-full` from the inner flex container meant the `bg-gray-900` sidebar could
  appear truncated in PDFs generated by `html2canvas`, which doesn't always reproduce CSS
  flex-stretch behavior faithfully. Fixed by adding `minHeight: '297mm'` directly on the
  sidebar div.